### PR TITLE
scitail_bigbio_te uses entails not entailment

### DIFF
--- a/promptsource/templates/scitail/scitail_bigbio_te/templates.yaml
+++ b/promptsource/templates/scitail/scitail_bigbio_te/templates.yaml
@@ -8,7 +8,7 @@ templates:
 
       {{ answer_choices | join('' or '') }}?
 
-      |||{% if label == "entailment" %}
+      |||{% if label == "entails" %}
 
       {{answer_choices[0]}}
 


### PR DESCRIPTION
scitail_bigbio_te uses entails not entailment

not positive that this is the right branch or place, but just wanted to flag this issue, 

the hf implementation of scitail uses `entailment`, the bigbio implementation uses `entails` 