### PR TITLE
adds chemprot templates (generated via streamlit)

### DIFF
--- a/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
+++ b/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
@@ -1,0 +1,171 @@
+dataset: chemprot
+subset: chemprot_bigbio_kb
+templates:
+  0cc837cf-b7f0-40ca-8d75-c23256bbc105: !Template
+    answer_choices: null
+    id: 0cc837cf-b7f0-40ca-8d75-c23256bbc105
+    jinja: '{% set ent_len = entities|length %}
+      {% set entity_text_id = range(0, ent_len) | random %}
+      {% if entities[entity_type_id]["type"] != "CHEMICAL"
+      %}
+      {% set answer = "Yes" %}
+      {% else %}
+      {% set answer = "No" %}
+      {% endif %}
+
+      {{passages[0][0]["text"] }}
+
+      In the passage above, is "{{ entity_text }}" an gene or protein type? Please
+      write {{ "Yes" }} or {{ "No" }}?
+
+      ||| {{ answer }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
+    name: is_gene_or_protein_chemprot
+    reference: Binary classification chemprot Gene/Protein
+  0cc837cf-b7f0-40ca-8d75-c23256bbc105: !Template
+    answer_choices: null
+    id: 0cc837cf-b7f0-40ca-8d75-c23256bbc105
+    jinja: '{% set ent_len = entities|length %}
+      {% set entity_text_id = range(0, ent_len) | random %}
+      {% if entities[entity_type_id]["type"] == "CHEMICAL"
+      %}
+      {% set answer = "Yes" %}
+      {% else %}
+      {% set answer = "No" %}
+      {% endif %}
+
+      {{passages[0][0]["text"] }}
+
+      In the passage above, is "{{ entity_text }}" a chemical? Please
+      write {{ "Yes" }} or {{ "No" }}?
+
+      ||| {{ answer }}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Accuracy
+      original_task: false
+    name: is_chemical_chemprot
+    reference: Binary classification chemical
+  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
+    answer_choices: null
+    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
+    jinja: 'What chemicals are upregulators to their protein gene targets?
+    Separate each chemical and gene or protein target pair with a comma.
+      If there are none, "None."
+
+      {{passages[0]["text"][0]}}
+      |||
+
+      {% if relations | length > 0 %}
+      {% for relation in relations %}
+      {% if relation["type"] == "Upregulator" %}
+
+      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
+      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
+      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
+      %}{% else %}None.{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_there_upregulator
+    reference: ''
+  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
+    answer_choices: null
+    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
+    jinja: 'What chemicals are downregulators to their protein gene targets?
+    Separate each chemical and gene or protein target pair with a comma.
+      If there are none, "None."
+
+      {{passages[0]["text"][0]}}
+      |||
+
+      {% if relations | length > 0 %}
+      {% for relation in relations %}
+      {% if relation["type"] == "Downregulator" %}
+
+      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
+      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
+      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
+      %}{% else %}None.{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_there_downregulator
+    reference: ''
+  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
+    answer_choices: null
+    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
+    jinja: 'What chemicals are agonists to their protein gene targets?
+    Separate each chemical and gene or protein target pair with a comma.
+      If there are none, "None."
+
+      {{passages[0]["text"][0]}}
+      |||
+
+      {% if relations | length > 0 %}
+      {% for relation in relations %}
+      {% if relation["type"] == "Agonist" %}
+
+      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
+      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
+      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
+      %}{% else %}None.{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_there_agonist
+    reference: ''
+  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
+    answer_choices: null
+    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
+    jinja: 'What chemicals are antagonists to their protein gene targets?
+    Separate each chemical and gene or protein target pair with a comma.
+      If there are none, "None."
+
+      {{passages[0]["text"][0]}}
+      |||
+
+      {% if relations | length > 0 %}
+      {% for relation in relations %}
+      {% if relation["type"] == "Antagonist" %}
+
+      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
+      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
+      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
+      %}{% else %}None.{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_there_antagonist
+    reference: ''
+  e520da97-7097-4755-b83c-f528a0232831: !Template
+    answer_choices: null
+    id: e520da97-7097-4755-b83c-f528a0232831
+    jinja: 'What pairs of chemicals and protein or gene targets exhibit some biological relationship?
+      {{passages[0]["text"][0]}}
+      |||
+      {% if relations | length > 0 %}{% for relation in relations %}
+      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
+      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
+      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
+      %}{% else %}None.{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: Types of relations without formatting
+    reference: ''

--- a/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
+++ b/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
@@ -8,12 +8,13 @@ templates:
       {% set entity_text_id = range(0, ent_len) | random %}
       {% if entities[entity_type_id]["type"] != "CHEMICAL"
       %}
+      {% set entity_text =  entities[entity_text_id]["text"][0] %}
       {% set answer = "Yes" %}
       {% else %}
       {% set answer = "No" %}
       {% endif %}
 
-      {{passages[0][0]["text"] }}
+      {{passages[0]["text"] }}
 
       In the passage above, is "{{ entity_text }}" an gene or protein type? Please
       write {{ "Yes" }} or {{ "No" }}?
@@ -33,12 +34,13 @@ templates:
       {% set entity_text_id = range(0, ent_len) | random %}
       {% if entities[entity_type_id]["type"] == "CHEMICAL"
       %}
+      {% set entity_text =  entities[entity_text_id]["text"][0] %}
       {% set answer = "Yes" %}
       {% else %}
       {% set answer = "No" %}
       {% endif %}
 
-      {{passages[0][0]["text"] }}
+      {{passages[0]["text"] }}
 
       In the passage above, is "{{ entity_text }}" a chemical? Please
       write {{ "Yes" }} or {{ "No" }}?

--- a/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
+++ b/promptsource/templates/chemprot/chemprot_bigbio_kb/templates.yaml
@@ -1,173 +1,215 @@
 dataset: chemprot
 subset: chemprot_bigbio_kb
 templates:
-  0cc837cf-b7f0-40ca-8d75-c23256bbc105: !Template
+  06cb141a-2cc5-4654-b00c-f372bfb520b6: !Template
     answer_choices: null
-    id: 0cc837cf-b7f0-40ca-8d75-c23256bbc105
+    id: 06cb141a-2cc5-4654-b00c-f372bfb520b6
+    jinja: '{{ passages[0][''text''][0] }}
+
+
+      What chemicals are upregulators to their protein or gene targets from the above
+      passage? Separate each chemical and gene or protein target pair with a comma.
+      If there are none, return nothing.
+
+
+      |||
+
+
+      {% if relations|length > 0 %}{% for relation in relations %}{% if relation[''type'']
+      == "Upregulator" %}{% for entity in entities %}{% if entity[''id''] == relation[''arg1_id'']
+      %}{{ entity[''text''][0] }}{% endif %}{% endfor %},{% for entity in entities
+      %}{% if entity[''id''] == relation[''arg2_id''] %}{{ entity[''text''][0] }}{%
+      endif %}{% endfor %}
+
+      {% endif %}{% endfor %}{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_upregulator
+    reference: Find all upregulator compounds
+  609340b7-d8e7-43e3-9ea8-bb76d3e84af9: !Template
+    answer_choices: Yes || No
+    id: 609340b7-d8e7-43e3-9ea8-bb76d3e84af9
     jinja: '{% set ent_len = entities|length %}
+
       {% set entity_text_id = range(0, ent_len) | random %}
-      {% if entities[entity_type_id]["type"] != "CHEMICAL"
-      %}
-      {% set entity_text =  entities[entity_text_id]["text"][0] %}
+
+      {% set etype = entities[entity_text_id][''text''][0] %}
+
+      {% if entities[entity_text_id][''type''] != "CHEMICAL" %}
+
       {% set answer = "Yes" %}
+
       {% else %}
+
       {% set answer = "No" %}
+
       {% endif %}
 
-      {{passages[0]["text"] }}
 
-      In the passage above, is "{{ entity_text }}" an gene or protein type? Please
-      write {{ "Yes" }} or {{ "No" }}?
+      {{ passages[0][''text''][0] }}
+
+
+
+      In the passage above, is "{{ etype }}" a chemical type? Please write {{ "Yes"
+      }} or {{ "No" }}?
 
       ||| {{ answer }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
-    name: is_gene_or_protein_chemprot
-    reference: Binary classification chemprot Gene/Protein
-  0cc837cf-b7f0-40ca-8d75-c23256bbc105: !Template
+      original_task: true
+    name: is_geneprotein_chemprot
+    reference: ''
+  629051fe-905a-4fc6-a751-0d0a05faa383: !Template
     answer_choices: null
-    id: 0cc837cf-b7f0-40ca-8d75-c23256bbc105
-    jinja: '{% set ent_len = entities|length %}
+    id: 629051fe-905a-4fc6-a751-0d0a05faa383
+    jinja: '{{ passages[0][''text''][0] }}
+
+
+      What chemicals are downregulators to their protein or gene targets from the
+      above passage? Separate each chemical and gene or protein target pair with a
+      comma. If there are none, return nothing.
+
+
+      |||
+
+
+      {% if relations|length > 0 %}{% for relation in relations %}{% if relation[''type'']
+      == "Downregulator" %}{% for entity in entities %}{% if entity[''id''] == relation[''arg1_id'']
+      %}{{ entity[''text''][0] }}{% endif %}{% endfor %},{% for entity in entities
+      %}{% if entity[''id''] == relation[''arg2_id''] %}{{ entity[''text''][0] }}{%
+      endif %}{% endfor %}
+
+      {% endif %}{% endfor %}{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
+    name: is_downregulator
+    reference: Are there downregulator compounds in the passage?
+  830f10a2-633a-43bd-a8df-997373b77ea7: !Template
+    answer_choices: null
+    id: 830f10a2-633a-43bd-a8df-997373b77ea7
+    jinja: '{{ passages[0][''text''][0] }}
+
+
+      What chemicals are agonists to their protein or gene targets from the above
+      passage? Separate each chemical and gene or protein target pair with a comma.
+      If there are none, return nothing.
+
+
+      |||
+
+
+      {% if relations|length > 0 %}{% for relation in relations %}{% if relation[''type'']
+      == "Agonist" %}{% for entity in entities %}{% if entity[''id''] == relation[''arg1_id'']
+      %}{{ entity[''text''][0] }}{% endif %}{% endfor %},{% for entity in entities
+      %}{% if entity[''id''] == relation[''arg2_id''] %}{{ entity[''text''][0] }}{%
+      endif %}{% endfor %}
+
+      {% endif %}{% endfor %}{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: false
+    name: is_agonist
+    reference: Are there compounds in the passage that are agonists?
+  9baf100f-d328-4920-ac83-4caa800d280f: !Template
+    answer_choices: null
+    id: 9baf100f-d328-4920-ac83-4caa800d280f
+    jinja: '{{ passages[0][''text''][0] }}
+
+
+      What chemicals are regulators to their protein or gene targets from the above
+      passage? Separate each chemical and gene or protein target pair with a comma.
+      If there are none, return nothing.
+
+
+      |||
+
+
+      {% if relations|length > 0 %}{% for relation in relations %}{% if relation[''type'']
+      == "Regulator" %}{% for entity in entities %}{% if entity[''id''] == relation[''arg1_id'']
+      %}{{ entity[''text''][0] }}{% endif %}{% endfor %},{% for entity in entities
+      %}{% if entity[''id''] == relation[''arg2_id''] %}{{ entity[''text''][0] }}{%
+      endif %}{% endfor %}
+
+      {% endif %}{% endfor %}{% endif %}'
+    metadata: !TemplateMetadata
+      choices_in_prompt: false
+      metrics:
+      - Other
+      original_task: true
+    name: is_regulator
+    reference: Which relations describe regulators between compound and protein/gene?
+  b3f07e34-9d41-4bd3-95e7-670f1346af21: !Template
+    answer_choices: Yes || No
+    id: b3f07e34-9d41-4bd3-95e7-670f1346af21
+    jinja: '
+
+      {% set ent_len = entities|length %}
+
       {% set entity_text_id = range(0, ent_len) | random %}
-      {% if entities[entity_type_id]["type"] == "CHEMICAL"
-      %}
-      {% set entity_text =  entities[entity_text_id]["text"][0] %}
+
+      {% set etype = entities[entity_text_id][''text''][0] %}
+
+      {% if entities[entity_text_id][''type''] == "CHEMICAL" %}
+
       {% set answer = "Yes" %}
+
       {% else %}
+
       {% set answer = "No" %}
+
       {% endif %}
 
-      {{passages[0]["text"] }}
 
-      In the passage above, is "{{ entity_text }}" a chemical? Please
-      write {{ "Yes" }} or {{ "No" }}?
+      {{ passages[0][''text''][0] }}
+
+
+
+      In the passage above, is "{{ etype }}" a chemical type? Please write {{ "Yes"
+      }} or {{ "No" }}?
 
       ||| {{ answer }}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Accuracy
-      original_task: false
+      original_task: true
     name: is_chemical_chemprot
-    reference: Binary classification chemical
-  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
+    reference: Is the following a chemical compound?
+  da2578a8-e3eb-46fe-a835-3d3c676a49a8: !Template
     answer_choices: null
-    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
-    jinja: 'What chemicals are upregulators to their protein gene targets?
-    Separate each chemical and gene or protein target pair with a comma.
-      If there are none, "None."
+    id: da2578a8-e3eb-46fe-a835-3d3c676a49a8
+    jinja: '{{ passages[0][''text''][0] }}
 
-      {{passages[0]["text"][0]}}
+
+      What chemicals are antagonists to their protein or gene targets from the above
+      passage? Separate each chemical and gene or protein target pair with a comma.
+      If there are none, return nothing.
+
+
       |||
 
-      {% if relations | length > 0 %}
-      {% for relation in relations %}
-      {% if relation["type"] == "Upregulator" %}
 
-      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
-      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
-      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
-      %}{% else %}None.{% endif %}'
+      {% if relations|length > 0 %}{% for relation in relations %}{% if relation[''type'']
+      == "Antagonist" %}{% for entity in entities %}{% if entity[''id''] == relation[''arg1_id'']
+      %}{{ entity[''text''][0] }}{% endif %}{% endfor %},{% for entity in entities
+      %}{% if entity[''id''] == relation[''arg2_id''] %}{{ entity[''text''][0] }}{%
+      endif %}{% endfor %}
+
+      {% endif %}{% endfor %}{% endif %}'
     metadata: !TemplateMetadata
       choices_in_prompt: false
       metrics:
       - Other
-      original_task: true
-    name: is_there_upregulator
-    reference: ''
-  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
-    answer_choices: null
-    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
-    jinja: 'What chemicals are downregulators to their protein gene targets?
-    Separate each chemical and gene or protein target pair with a comma.
-      If there are none, "None."
-
-      {{passages[0]["text"][0]}}
-      |||
-
-      {% if relations | length > 0 %}
-      {% for relation in relations %}
-      {% if relation["type"] == "Downregulator" %}
-
-      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
-      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
-      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
-      %}{% else %}None.{% endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: is_there_downregulator
-    reference: ''
-  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
-    answer_choices: null
-    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
-    jinja: 'What chemicals are agonists to their protein gene targets?
-    Separate each chemical and gene or protein target pair with a comma.
-      If there are none, "None."
-
-      {{passages[0]["text"][0]}}
-      |||
-
-      {% if relations | length > 0 %}
-      {% for relation in relations %}
-      {% if relation["type"] == "Agonist" %}
-
-      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
-      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
-      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
-      %}{% else %}None.{% endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: is_there_agonist
-    reference: ''
-  2775762b-42c5-46e1-8fc2-c4d2b0d82b0c: !Template
-    answer_choices: null
-    id: 2775762b-42c5-46e1-8fc2-c4d2b0d82b0c
-    jinja: 'What chemicals are antagonists to their protein gene targets?
-    Separate each chemical and gene or protein target pair with a comma.
-      If there are none, "None."
-
-      {{passages[0]["text"][0]}}
-      |||
-
-      {% if relations | length > 0 %}
-      {% for relation in relations %}
-      {% if relation["type"] == "Antagonist" %}
-
-      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
-      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
-      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
-      %}{% else %}None.{% endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: is_there_antagonist
-    reference: ''
-  e520da97-7097-4755-b83c-f528a0232831: !Template
-    answer_choices: null
-    id: e520da97-7097-4755-b83c-f528a0232831
-    jinja: 'What pairs of chemicals and protein or gene targets exhibit some biological relationship?
-      {{passages[0]["text"][0]}}
-      |||
-      {% if relations | length > 0 %}{% for relation in relations %}
-      {% for entity in entities %}{% if entity["id"] == relation["arg1_id"] %}{{ entity["text"][0]
-      }}{% endif %}{% endfor %}, {% for entity in entities %}{% if entity["id"] ==
-      relation["arg2_id"] %}{{ entity["text"][0] }} {% endif %}{% endfor %}{% endfor
-      %}{% else %}None.{% endif %}'
-    metadata: !TemplateMetadata
-      choices_in_prompt: false
-      metrics:
-      - Other
-      original_task: true
-    name: Types of relations without formatting
+      original_task: false
+    name: is_antagonist
     reference: ''


### PR DESCRIPTION
EDIT (2022.05.31) - I regenerated these with the streamlit app, hence they should be properly formed jinja.

@stephenbach A very bad first pass at chemprot prompting. I truthfully am clueless with jinja, so I tried to use both your DDI prompts (which were very clever) and chemdner. I am happy to credit both to whatever is necessary. Do you think you could review and/or tidy this up?

Notably, I may need to regenerate hash IDs for each of the scripts as I'm unable to get the streamlit app working for GUI-based editing. If possible, I'd vastly prefer a manual curation, if possible.